### PR TITLE
Use '-f' flag for Go Get

### DIFF
--- a/get.go
+++ b/get.go
@@ -27,7 +27,7 @@ func get(dir string) {
 			err = fetch(imp, gopathPrefix)
 		} else {
 			log.Printf("go get %s...", imp)
-			err = execute("", "go", "get", "-u", imp)
+			err = execute("", "go", "get", "-f", "-u", imp)
 		}
 		if err != nil {
 			log.Printf("%s", err)


### PR DESCRIPTION
  I am not sure if this presents a security risk or not.  It is
  common to modify one's git config to use ssh for accessing private
  repositories through 'go get'.  Subsequently Go begins to throw up
  warnings about fetching code from the wrong repository.

  This silences these warnings.
